### PR TITLE
game feel tweaks to camera and player movement

### DIFF
--- a/src/game/camera.rs
+++ b/src/game/camera.rs
@@ -28,10 +28,10 @@ fn spawn_camera(mut commands: Commands) {
         IsDefaultUiCamera,
         CameraProperties {
             initial_camera_zoom: INITIAL_CAMERA_ZOOM,
-            camera_zoom_snappiness: 0.025,
-            mouse_wheel_sensitivity: 0.5,
+            camera_zoom_snappiness: 0.2,
+            mouse_wheel_sensitivity: 30.,
             camera_zoom_max: 1.5,
-            camera_zoom_min: 0.3,
+            camera_zoom_min: 0.2,
             camera_zoom_buffer: 0.01,
         },
         CanZoomSmoothly(INITIAL_CAMERA_ZOOM),

--- a/src/game/grid/mod.rs
+++ b/src/game/grid/mod.rs
@@ -174,10 +174,10 @@ pub mod movement {
         fn default() -> Self {
             Self {
                 velocity: Vec2::ZERO,
-                friction: 0.9,
+                friction: 0.85,
                 acceleration_player_force: Vec2::ZERO,
                 acceleration_external_force: Vec2::ZERO,
-                acceleration_player_multiplier: 25.,
+                acceleration_player_multiplier: 66.,
             }
         }
     }


### PR DESCRIPTION
Tweak some camera and movement values to make everything feel more snappy and responsive

- camera sensitivity upped by a lot to facilitate quickly overviewing the map, then zooming back in for sneaking action
- allow zooming in a bit further just for fun

friction
- snappiness (camera friction) increased so it's less "floaty"
- increase player friction for the same reason
- movement acceleration increased ~2x, partially to make it feel better and partially to counteract the increased friction