### PR TITLE
Added new camera features and Retweaked camera zoom and follow code to improve game feel on mac.

### DIFF
--- a/src/game/camera.rs
+++ b/src/game/camera.rs
@@ -3,7 +3,7 @@ use bevy::input::mouse::MouseScrollUnit;
 use bevy::input::mouse::MouseWheel;
 use bevy::prelude::*;
 
-use crate::game::spawn::level::{GRID_SIZE, LevelWalls};
+use crate::game::spawn::level::{LevelWalls, GRID_SIZE};
 use crate::game::spawn::player::Player;
 use crate::postprocessing::PostProcessSettings;
 

--- a/src/game/camera.rs
+++ b/src/game/camera.rs
@@ -1,14 +1,28 @@
-use crate::game::spawn::player::Player;
-use crate::postprocessing::PostProcessSettings;
+use std::cmp::min;
+
 use bevy::core::Name;
 use bevy::input::mouse::MouseScrollUnit;
 use bevy::input::mouse::MouseWheel;
 use bevy::prelude::*;
+use bevy_egui::systems::InputEvents;
+
+use crate::game::spawn::level::{GRID_SIZE, LevelWalls};
+use crate::game::spawn::player::Player;
+use crate::postprocessing::PostProcessSettings;
 
 pub(super) fn plugin(app: &mut App) {
     app.register_type::<CameraProperties>();
     app.add_systems(Startup, spawn_camera);
-    app.add_systems(Update, (camera_zoom, camera_follow));
+    app.add_systems(
+        Update,
+        (
+            record_binary_zoom_input,
+            record_smooth_zoom_input,
+            apply_camera_zoom,
+            camera_follow,
+        )
+            .chain(),
+    );
 }
 
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Default, Reflect)]
@@ -28,11 +42,13 @@ fn spawn_camera(mut commands: Commands) {
         IsDefaultUiCamera,
         CameraProperties {
             initial_camera_zoom: INITIAL_CAMERA_ZOOM,
-            camera_zoom_snappiness: 0.2,
-            mouse_wheel_sensitivity: 30.,
-            camera_zoom_max: 1.5,
+            camera_zoom_snappiness: 20.0,
+            zoom_sensitivity: 1.0,
+            mouse_wheel_sensitivity_multiplier: 5.0,
+            camera_zoom_max: 1.1,
             camera_zoom_min: 0.2,
             camera_zoom_buffer: 0.01,
+            camera_follow_snappiness: 10.0,
         },
         CanZoomSmoothly(INITIAL_CAMERA_ZOOM),
         PostProcessSettings { intensity: 0.00005 },
@@ -45,32 +61,27 @@ const INITIAL_CAMERA_ZOOM: f32 = 0.3;
 pub struct CameraProperties {
     initial_camera_zoom: f32,
     camera_zoom_snappiness: f32,
-    mouse_wheel_sensitivity: f32,
+    zoom_sensitivity: f32,
+    mouse_wheel_sensitivity_multiplier: f32,
     camera_zoom_max: f32,
     camera_zoom_min: f32,
     camera_zoom_buffer: f32,
+    camera_follow_snappiness: f32,
 }
 
-fn camera_zoom(
+fn record_smooth_zoom_input(
     mut evr_scroll: EventReader<MouseWheel>,
     time: Res<Time>,
-    mut query: Query<
-        (
-            &mut OrthographicProjection,
-            &mut CanZoomSmoothly,
-            &CameraProperties,
-        ),
-        With<Camera>,
-    >,
+    mut query: Query<(&mut CanZoomSmoothly, &CameraProperties), With<Camera>>,
 ) {
-    if let Ok((mut projection, mut zoom_destination, camera_properties)) = query.get_single_mut() {
+    if let Ok((mut zoom_destination, camera_properties)) = query.get_single_mut() {
         // handle scroll wheel input
         for ev in evr_scroll.read() {
-            let dist = camera_properties.mouse_wheel_sensitivity * time.delta().as_secs_f32();
+            let dist = camera_properties.zoom_sensitivity * time.delta().as_secs_f32();
             let mut log_scale = zoom_destination.0.ln();
             match ev.unit {
                 MouseScrollUnit::Line => {
-                    log_scale -= ev.y * dist;
+                    log_scale -= ev.y * dist * camera_properties.mouse_wheel_sensitivity_multiplier;
                 }
                 MouseScrollUnit::Pixel => {
                     log_scale -= ev.y * dist;
@@ -84,13 +95,42 @@ fn camera_zoom(
                 zoom_destination.0 = log_scale.exp();
             }
         }
+    }
+}
 
+fn record_binary_zoom_input(
+    input: Res<ButtonInput<KeyCode>>,
+    mut query: Query<(&mut CanZoomSmoothly, &CameraProperties), With<Camera>>,
+) {
+    if let Ok((mut zoom_destination, camera_properties)) = query.get_single_mut() {
+        // handle player input
+        if input.pressed(KeyCode::Space) {
+            zoom_destination.0 = camera_properties.camera_zoom_max;
+        } else if input.just_released(KeyCode::Space) {
+            zoom_destination.0 = camera_properties.initial_camera_zoom;
+        }
+    }
+}
+
+fn apply_camera_zoom(
+    time: Res<Time>,
+    mut query: Query<
+        (
+            &mut OrthographicProjection,
+            &CanZoomSmoothly,
+            &CameraProperties,
+        ),
+        With<Camera>,
+    >,
+) {
+    if let Ok((mut projection, zoom_destination, camera_properties)) = query.get_single_mut() {
         // handle smooth zoom over time
         if projection.scale < zoom_destination.0 - camera_properties.camera_zoom_buffer
             || projection.scale > zoom_destination.0 + camera_properties.camera_zoom_buffer
         {
             projection.scale += (zoom_destination.0 - projection.scale)
-                * (camera_properties.camera_zoom_snappiness);
+                * (camera_properties.camera_zoom_snappiness)
+                * time.delta_seconds();
         }
         projection.scale = projection.scale.clamp(
             camera_properties.camera_zoom_min,
@@ -100,13 +140,44 @@ fn camera_zoom(
 }
 
 fn camera_follow(
-    mut camera: Query<&mut Transform, (With<Camera>, Without<Player>)>,
+    mut camera: Query<
+        (&mut Transform, &OrthographicProjection, &CameraProperties),
+        (With<Camera>, Without<Player>),
+    >,
     target: Query<&Transform, (With<CanBeFollowedByCamera>, Without<Camera>)>,
+    level_walls: Res<LevelWalls>,
+    time: Res<Time>,
 ) {
     if let Ok(target_transform) = target.get_single() {
-        if let Ok(mut camera_transform) = camera.get_single_mut() {
-            let lerp = (target_transform.translation - camera_transform.translation) * 0.05;
+        if let Ok((mut camera_transform, orthographic, properties)) = camera.get_single_mut() {
+            //calculate bounds
+            let vertical_bounds = orthographic.area.height();
+            let horizontal_bounds = orthographic.area.width();
+            let level_width = (level_walls.level_width * GRID_SIZE) as f32;
+            let level_height = (level_walls.level_height * GRID_SIZE) as f32;
+            let min_x = (horizontal_bounds / 2.0).min(level_width / 2.0);
+            let max_x = (level_width - horizontal_bounds / 2.0).max(level_width / 2.0);
+            let min_y = (vertical_bounds / 2.0).min(level_height / 2.0);
+            let max_y = (level_height - vertical_bounds / 2.0).max(level_height / 2.0);
+
+            let bounded_target_position = Vec3::new(
+                target_transform.translation.x.clamp(min_x, max_x),
+                target_transform.translation.y.clamp(min_y, max_y),
+                target_transform.translation.z,
+            );
+
+            //smoothly interpolate camera position to target position
+            let lerp = (bounded_target_position - camera_transform.translation)
+                * properties.camera_follow_snappiness
+                * time.delta_seconds();
             camera_transform.translation += lerp;
+
+            //and hard clam that camera's position if it is out of bounds
+            camera_transform.translation = Vec3::new(
+                camera_transform.translation.x.clamp(min_x, max_x),
+                camera_transform.translation.y.clamp(min_y, max_y),
+                camera_transform.translation.z,
+            );
         }
     }
 }

--- a/src/game/camera.rs
+++ b/src/game/camera.rs
@@ -1,10 +1,7 @@
-use std::cmp::min;
-
 use bevy::core::Name;
 use bevy::input::mouse::MouseScrollUnit;
 use bevy::input::mouse::MouseWheel;
 use bevy::prelude::*;
-use bevy_egui::systems::InputEvents;
 
 use crate::game::spawn::level::{GRID_SIZE, LevelWalls};
 use crate::game::spawn::player::Player;

--- a/src/game/spawn/level.rs
+++ b/src/game/spawn/level.rs
@@ -1,12 +1,15 @@
 //! Spawn the main level by triggering other observers.
 
-use super::player::SpawnPlayerTrigger;
-use crate::game::spawn::ldtk::LdtkEntityBundle;
+use std::collections::HashSet;
+
 use bevy::prelude::*;
+use bevy_ecs_ldtk::{GridCoords, LdtkIntCell, LevelEvent};
 use bevy_ecs_ldtk::assets::LdtkProject;
 use bevy_ecs_ldtk::prelude::{LdtkEntityAppExt, LdtkIntCellAppExt, LevelMetadataAccessor};
-use bevy_ecs_ldtk::{GridCoords, LdtkIntCell, LevelEvent};
-use std::collections::HashSet;
+
+use crate::game::spawn::ldtk::LdtkEntityBundle;
+
+use super::player::SpawnPlayerTrigger;
 
 pub(super) fn plugin(app: &mut App) {
     app.observe(spawn_level);
@@ -19,7 +22,7 @@ pub(super) fn plugin(app: &mut App) {
     app.register_type::<LevelWalls>();
 }
 
-const GRID_SIZE: i32 = 16;
+pub const GRID_SIZE: i32 = 16;
 
 #[derive(Default, Component)]
 struct Wall;

--- a/src/game/spawn/level.rs
+++ b/src/game/spawn/level.rs
@@ -3,9 +3,9 @@
 use std::collections::HashSet;
 
 use bevy::prelude::*;
-use bevy_ecs_ldtk::{GridCoords, LdtkIntCell, LevelEvent};
 use bevy_ecs_ldtk::assets::LdtkProject;
 use bevy_ecs_ldtk::prelude::{LdtkEntityAppExt, LdtkIntCellAppExt, LevelMetadataAccessor};
+use bevy_ecs_ldtk::{GridCoords, LdtkIntCell, LevelEvent};
 
 use crate::game::spawn::ldtk::LdtkEntityBundle;
 


### PR DESCRIPTION
Added camera bounding so the camera tries not to show areas outside the level when zooming out.

Added an ability for players to press and hold the spacebar to quickly view the zoomed out map. We may want to get rid of the scroll-wheel zoom for the final release, depending on if we want to make zooming out a mechanic where you need to stand still to do it.