### PR TITLE
Fix visibility cone update interval

### DIFF
--- a/src/game/line_of_sight/vision.rs
+++ b/src/game/line_of_sight/vision.rs
@@ -3,11 +3,11 @@ use std::f32::consts;
 use bevy::prelude::*;
 use bevy::utils::HashSet;
 
-use crate::AppSet;
 use crate::game::grid::grid_layout::GridLayout;
 use crate::game::grid::GridPosition;
 use crate::game::line_of_sight::FacingWallsCache;
 use crate::geometry_2d::line_segment::LineSegment;
+use crate::AppSet;
 
 pub fn plugin(app: &mut App) {
     // systems

--- a/src/game/line_of_sight/vision.rs
+++ b/src/game/line_of_sight/vision.rs
@@ -130,7 +130,7 @@ pub fn update_visible_squares(
         if ray_start.distance(visible_squares.for_position.coordinates) < 1.0 {
             continue;
         }
-        visible_squares.for_position = grid_position.clone();
+        visible_squares.for_position = *grid_position;
 
         let mut new_squares = vec![];
 

--- a/src/game/line_of_sight/vision.rs
+++ b/src/game/line_of_sight/vision.rs
@@ -3,11 +3,11 @@ use std::f32::consts;
 use bevy::prelude::*;
 use bevy::utils::HashSet;
 
+use crate::AppSet;
 use crate::game::grid::grid_layout::GridLayout;
 use crate::game::grid::GridPosition;
 use crate::game::line_of_sight::FacingWallsCache;
 use crate::geometry_2d::line_segment::LineSegment;
-use crate::AppSet;
 
 pub fn plugin(app: &mut App) {
     // systems
@@ -130,6 +130,7 @@ pub fn update_visible_squares(
         if ray_start.distance(visible_squares.for_position.coordinates) < 1.0 {
             continue;
         }
+        visible_squares.for_position = grid_position.clone();
 
         let mut new_squares = vec![];
 


### PR DESCRIPTION
They were supposed to only recompute when the entity moves a whole grid position, but i wasn't setting the cache key so they were being recomputed every update.

This system used to take ~2.5ms average per frame

Now it's ~0.3ms per frame (almost a 10x improvement)